### PR TITLE
Fix docker connect

### DIFF
--- a/src/fastpath.c
+++ b/src/fastpath.c
@@ -175,7 +175,9 @@ int fetch_image(char *image_name, char *tag, char *user, char *pass) {
         if (homedir) {
             debug("Trying to fetch credentials from Docker client configuration\n");
             sprintf(filename, "%s/%s", homedir, CONFIG_FILE_PATH);
+            debug('hereA\n');
             fp = fopen(filename, "r");
+            debug('hereB\n');
             if (fp == NULL) {
                 debug("Cannot open Docker client configuration file: %s\n", strerror(errno));
             } else {
@@ -219,13 +221,30 @@ end:
         debug("No credentials\n");
     }
 
-    curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, "/var/run/docker.sock");
+    debug("here0\n");
+    const char* s = getenv("DOCKER_HOST");
+    char* host = "";
+    debug("here1\n");
+    if (s == NULL) {
+        debug("here2\n");
+        // If no DOCKER_HOST, default to unix socket connection
+        curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, "/var/run/docker.sock");
+        debug("here3\n");
+    } else {
+        debug("here4\n");
+        first_slash = strchr(s, '/');
+        debug("here5\n");
+        if (first_slash != NULL) {
+            debug("here6\n");
+            host = first_slash;
+        }
+    }
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_function);
 
     // input sanitation?
-    sprintf(url, "http://v1.18/images/create?fromImage=%s&tag=%s", image_name, tag);
+    sprintf(url, "http://%sv1.18/images/create?fromImage=%s&tag=%s", host, image_name, tag);
     curl_easy_setopt(curl, CURLOPT_URL, url);
 
     debug("Trying to fetch %s:%s\n", image_name, tag);

--- a/src/fastpath.c
+++ b/src/fastpath.c
@@ -219,8 +219,8 @@ end:
         debug("No credentials\n");
     }
 
+    char* docker_host = NULL;
     const char* s = getenv("DOCKER_HOST");
-    char* host = "";
     if (s == NULL) {
         // If no DOCKER_HOST, default to unix socket connection
         curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, "/var/run/docker.sock");
@@ -228,16 +228,16 @@ end:
     } else {
         char* last_slash = strrchr(s, '/');
         if (last_slash != NULL) {
-            host = last_slash + 1;
+            docker_host = last_slash + 1;
         }
-        debug("using DOCKER_HOST parsed as %s\n", host);
+        debug("using DOCKER_HOST parsed as %s\n", docker_host);
     }
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_function);
 
-    if (host) {
-        sprintf(url, "http://%s/v1.18/images/create?fromImage=%s&tag=%s", host, image_name, tag);
+    if (docker_host) {
+        sprintf(url, "http://%s/v1.18/images/create?fromImage=%s&tag=%s", docker_host, image_name, tag);
     } else {
         sprintf(url, "http://v1.18/images/create?fromImage=%s&tag=%s", image_name, tag);
     }


### PR DESCRIPTION
The app assumes Docker is running locally and accessible via /var/run/docker.sock, but this is not the case if we are using Remote Docker. This adds support for the `DOCKER_HOST` envvar, using that host to communicate with Docker instead of the local unix socket, when present. It also needs to use the SSL certs provided in the path `DOCKER_CERT_PATH`.